### PR TITLE
TODO閲覧機能の追加

### DIFF
--- a/src/main/java/com/example/todoapp/AuthenticatedUserController.java
+++ b/src/main/java/com/example/todoapp/AuthenticatedUserController.java
@@ -1,0 +1,143 @@
+package com.example.todoapp;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+import com.example.todoapp.repositories.TodoRepository;
+
+@Controller
+@RequestMapping("/todo")
+public class AuthenticatedUserController {
+	
+	@Autowired
+	TodoRepository repository;
+	
+	@Autowired
+	TodoService todoService;
+	
+	@GetMapping("/create")
+	@PreAuthorize("isAuthenticated()")
+	public ModelAndView create(ModelAndView mav, @ModelAttribute Todo todoItem) {
+		// ログイン中のユーザー情報を取得
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		String username = authentication.getName();
+		
+		mav.setViewName("todo/create");
+		mav.addObject("title", "TODO管理ページ");
+		mav.addObject("formModel", todoItem);
+		
+		List<Todo> data = repository.findByUsername(username);
+		mav.addObject("name", username + " さんのTODO一覧");
+		mav.addObject("data", data);
+		
+		// 期日が閲覧時点より7日以内かつ未完了のTODOは赤色に表示させる
+		List<Boolean> deadlineFlagLists = isNearDeadlineList(data);
+		mav.addObject("deadlineFlagLists", deadlineFlagLists);
+		mav.addObject("dayOfNow", LocalDate.now());
+		
+		return mav;
+	}
+	
+	@PostMapping("/create")
+	@PreAuthorize("isAuthenticated()")
+	public ModelAndView createForm(ModelAndView mav, @ModelAttribute("formModel") @Validated Todo todoItem, BindingResult result) {
+		// ログイン中のユーザー情報を取得
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		String username = authentication.getName();
+		
+		if(result.hasErrors()) {
+			System.out.println("Validation errors: " + result.getAllErrors());
+			
+			mav.setViewName("todo/create");
+			mav.addObject("title", "TODO管理ページ");
+			mav.addObject("formModel", todoItem);
+			
+			List<Todo> data = repository.findByUsername(username);
+			mav.addObject("name", username + " さんのTODO一覧");
+			mav.addObject("data", data);
+			
+			List<Boolean> deadlineFlagLists = isNearDeadlineList(data);
+			mav.addObject("deadlineFlagLists", deadlineFlagLists);
+			mav.addObject("dayOfNow", LocalDate.now());
+			
+			return mav;
+		}
+		
+		todoService.create(username, todoItem);
+		
+		return new ModelAndView("redirect:/todo/create");
+	}
+	
+	@GetMapping("/admin")
+	@PreAuthorize("hasRole('ADMIN')")
+	public ModelAndView admin(ModelAndView mav) {
+		mav.setViewName("todo/admin");
+		mav.addObject("title", "管理者専用ページ");
+		mav.addObject("msg", "全ユーザーTODO一覧");
+		
+		List<Todo> data = repository.findAll();
+		mav.addObject("data", data);
+		
+		List<Boolean> deadlineFlagLists = isNearDeadlineList(data);
+		mav.addObject("deadlineFlagLists", deadlineFlagLists);
+		mav.addObject("dayOfNow", LocalDate.now());
+		
+		return mav;
+	}
+	
+	// 各オブジェクトに設定されている期日が現時点より7日以内かつ未完了状態か判定する
+	private List<Boolean> isNearDeadlineList(List<Todo> dataLists) {
+		int dayOfNow = LocalDate.now().getDayOfYear();
+		List<Boolean> isNearDeadlineList = new ArrayList<>();
+		
+		for(Todo list : dataLists) {
+			boolean isNearDeadline = false;
+			
+			if(list.getDeadline() != null) {
+				int dayOfDeadline = list.getDeadline().getDayOfYear();
+				
+				if(dayOfDeadline - dayOfNow <= 7 && !list.isDone()) {
+					isNearDeadline = true;
+				}
+			}
+			
+			isNearDeadlineList.add(isNearDeadline);
+		}
+		
+		return isNearDeadlineList;
+	}
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/com/example/todoapp/AuthenticatedUserController.java
+++ b/src/main/java/com/example/todoapp/AuthenticatedUserController.java
@@ -45,9 +45,9 @@ public class AuthenticatedUserController {
 		mav.addObject("data", data);
 		
 		// 期日が閲覧時点より7日以内かつ未完了のTODOは赤色に表示させる
-		List<Boolean> deadlineFlagLists = isNearDeadlineList(data);
-		mav.addObject("deadlineFlagLists", deadlineFlagLists);
-		mav.addObject("dayOfNow", LocalDate.now());
+		List<Boolean> deadlineFlagList = isNearDeadlineList(data);
+		mav.addObject("deadlineFlagList", deadlineFlagList);
+		mav.addObject("today", LocalDate.now());
 		
 		return mav;
 	}
@@ -70,9 +70,9 @@ public class AuthenticatedUserController {
 			mav.addObject("name", username + " さんのTODO一覧");
 			mav.addObject("data", data);
 			
-			List<Boolean> deadlineFlagLists = isNearDeadlineList(data);
-			mav.addObject("deadlineFlagLists", deadlineFlagLists);
-			mav.addObject("dayOfNow", LocalDate.now());
+			List<Boolean> deadlineFlagList = isNearDeadlineList(data);
+			mav.addObject("deadlineFlagList", deadlineFlagList);
+			mav.addObject("today", LocalDate.now());
 			
 			return mav;
 		}
@@ -92,25 +92,25 @@ public class AuthenticatedUserController {
 		List<Todo> data = repository.findAll();
 		mav.addObject("data", data);
 		
-		List<Boolean> deadlineFlagLists = isNearDeadlineList(data);
-		mav.addObject("deadlineFlagLists", deadlineFlagLists);
-		mav.addObject("dayOfNow", LocalDate.now());
+		List<Boolean> deadlineFlagList = isNearDeadlineList(data);
+		mav.addObject("deadlineFlagList", deadlineFlagList);
+		mav.addObject("today", LocalDate.now());
 		
 		return mav;
 	}
 	
 	// 各オブジェクトに設定されている期日が現時点より7日以内かつ未完了状態か判定する
 	private List<Boolean> isNearDeadlineList(List<Todo> dataLists) {
-		int dayOfNow = LocalDate.now().getDayOfYear();
+		LocalDate notifyDate = LocalDate.now().plusDays(7);
 		List<Boolean> isNearDeadlineList = new ArrayList<>();
 		
 		for(Todo list : dataLists) {
 			boolean isNearDeadline = false;
 			
 			if(list.getDeadline() != null) {
-				int dayOfDeadline = list.getDeadline().getDayOfYear();
+				LocalDate dateOfDeadline = list.getDeadline();
 				
-				if(dayOfDeadline - dayOfNow <= 7 && !list.isDone()) {
+				if(dateOfDeadline.isBefore(notifyDate) && !list.isDone()) {
 					isNearDeadline = true;
 				}
 			}
@@ -121,23 +121,3 @@ public class AuthenticatedUserController {
 		return isNearDeadlineList;
 	}
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/main/java/com/example/todoapp/TodoController.java
+++ b/src/main/java/com/example/todoapp/TodoController.java
@@ -11,8 +11,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
-import jakarta.servlet.http.HttpServletRequest;
-
 @Controller
 public class TodoController {
 	
@@ -27,7 +25,7 @@ public class TodoController {
 	
 	@GetMapping("/secret")
 	@PreAuthorize("isAuthenticated()")
-	public ModelAndView secret(ModelAndView mav, HttpServletRequest request) {
+	public ModelAndView secret(ModelAndView mav) {
 		// ログイン中のユーザー名、ユーザー権限を取得
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 		String username = authentication.getName();

--- a/src/main/java/com/example/todoapp/TodoSecurityCinfig.java
+++ b/src/main/java/com/example/todoapp/TodoSecurityCinfig.java
@@ -39,6 +39,7 @@ public class TodoSecurityCinfig {
 		// またはアカウントを追加したい場合下記コードを実行
 //		JdbcUserDetailsManager users = new JdbcUserDetailsManager(this.dataSource);
 //		users.createUser(makeUser("user", "pass", "USER"));
+//		users.createUser(makeUser("Taro", "asou", "ADMIN"));
 //		return users;
 	}
 	

--- a/src/main/java/com/example/todoapp/repositories/TodoRepository.java
+++ b/src/main/java/com/example/todoapp/repositories/TodoRepository.java
@@ -1,5 +1,7 @@
 package com.example.todoapp.repositories;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,5 +9,5 @@ import com.example.todoapp.Todo;
 
 @Repository
 public interface TodoRepository extends JpaRepository<Todo, Long> {
-
+	public List<Todo> findByUsername(String name);
 }

--- a/src/main/resources/templates/secret.html
+++ b/src/main/resources/templates/secret.html
@@ -11,7 +11,12 @@
 		<h3 th:text="${msg}"></h3>
 		
 		<p class="fs-5">
-			<a class="fw-bold" th:href="@{/todo/create}">TODO作成</a>
+			<a class="fw-bold" th:href="@{/todo/create}">TODO管理ページへ</a>
+		</p>
+		
+		<!-- Adminユーザのみ表示 -->
+		<p class="fs-5" th:if="${isAdmin}">
+			<a class="fw-bold" th:href="@{/todo/admin}">管理者専用ページへ</a>
 		</p>
 		
 		<p class="fs-5">

--- a/src/main/resources/templates/todo/admin.html
+++ b/src/main/resources/templates/todo/admin.html
@@ -23,7 +23,7 @@
 		<!-- 全ユーザーTODO一覧表示 -->
 		<h2 class="fw-bold mt-5" th:text="${msg}"></h2>
 		<p class="fw-bold text-decoration-underline caution">
-			※赤く表示されているTODOは期日が現時点(<span th:text="${dayOfNow}"></span>)より7日以内のものです
+			※赤く表示されているTODOは期日が現時点(<span th:text="${today}"></span>)より7日以内のものです
 		</p>
 		<table class="table">
 			<thead>
@@ -38,12 +38,12 @@
 			</thead>
 			<tbody>
 				<tr th:each="item, status : ${data}">
-					<td th:text="${status.count}" th:class="${deadlineFlagLists[status.index]} ? 'nearbyDeadlines' : ''"></td>
-					<td th:text="${item.username}" th:class="${deadlineFlagLists[status.index]} ? 'nearbyDeadlines' : ''"></td>
-					<td th:text="${item.done} ? '完了' : '未完了'" th:class="${deadlineFlagLists[status.index]} ? 'nearbyDeadlines' : ''"></td>
-					<td th:text="${item.content}" th:class="${deadlineFlagLists[status.index]} ? 'nearbyDeadlines' : ''"></td>
-					<td th:text="${item.created}" th:class="${deadlineFlagLists[status.index]} ? 'nearbyDeadlines' : ''"></td>
-					<td th:text="${item.deadline}" th:class="${deadlineFlagLists[status.index]} ? 'nearbyDeadlines' : ''"></td>
+					<td th:text="${status.count}" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
+					<td th:text="${item.username}" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
+					<td th:text="${item.done} ? '完了' : '未完了'" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
+					<td th:text="${item.content}" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
+					<td th:text="${item.created}" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
+					<td th:text="${item.deadline}" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
 				</tr>
 			</tbody>
 		</table>

--- a/src/main/resources/templates/todo/admin.html
+++ b/src/main/resources/templates/todo/admin.html
@@ -6,11 +6,11 @@
 		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"
 			integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
 		<style>
-			.err, .caution { color: red; }
 			.nearbyDeadlines {
 				background-color: red !important;
 				font-weight: bold;
 			}
+			.caution { color: red; }
 		</style>
 	</head>
 	<body class="container">
@@ -20,26 +20,8 @@
 			<a class="fw-bold" th:href="@{/logout}">ログアウトする</a>
 		</p>
 		
-		<!-- TODO作成用フォーム -->
-		<h2 class="fw-bold mt-5">TODO作成</h2>
-		<form method="post" th:action="@{/todo/create}" th:object="${formModel}">
-			<div class="mb-4">
-				<label class="form-label" for="content">TODO</label>
-				<input class="form-control" type="text" id="content" name="content" th:value="*{content}">
-				<p th:if="${#fields.hasErrors('content')}" th:errors="*{content}" th:errorclass="err"></p>
-			</div>
-			
-			<div class="mb-4">
-				<label class="form-label" for="deadline">期日</label>
-				<input class="form-control" type="date" id="deadline" name="deadline" th:value="*{deadline}">
-				<p th:if="${#fields.hasErrors('deadline')}" th:errors="*{deadline}" th:errorclass="err"></p>
-			</div>
-			
-			<input type="submit" class="btn btn-primary" value="追加">
-		</form>
-		
-		<!-- TODO一覧表示 -->
-		<h2 class="fw-bold mt-5" th:text="${name}"></h2>
+		<!-- 全ユーザーTODO一覧表示 -->
+		<h2 class="fw-bold mt-5" th:text="${msg}"></h2>
 		<p class="fw-bold text-decoration-underline caution">
 			※赤く表示されているTODOは期日が現時点(<span th:text="${dayOfNow}"></span>)より7日以内のものです
 		</p>
@@ -47,6 +29,7 @@
 			<thead>
 				<tr>
 					<th>No.</th>
+					<th>ユーザー名</th>
 					<th>完了状態</th>
 					<th>TODO</th>
 					<th>作成日</th>
@@ -56,6 +39,7 @@
 			<tbody>
 				<tr th:each="item, status : ${data}">
 					<td th:text="${status.count}" th:class="${deadlineFlagLists[status.index]} ? 'nearbyDeadlines' : ''"></td>
+					<td th:text="${item.username}" th:class="${deadlineFlagLists[status.index]} ? 'nearbyDeadlines' : ''"></td>
 					<td th:text="${item.done} ? '完了' : '未完了'" th:class="${deadlineFlagLists[status.index]} ? 'nearbyDeadlines' : ''"></td>
 					<td th:text="${item.content}" th:class="${deadlineFlagLists[status.index]} ? 'nearbyDeadlines' : ''"></td>
 					<td th:text="${item.created}" th:class="${deadlineFlagLists[status.index]} ? 'nearbyDeadlines' : ''"></td>

--- a/src/main/resources/templates/todo/create.html
+++ b/src/main/resources/templates/todo/create.html
@@ -41,7 +41,7 @@
 		<!-- TODO一覧表示 -->
 		<h2 class="fw-bold mt-5" th:text="${name}"></h2>
 		<p class="fw-bold text-decoration-underline caution">
-			※赤く表示されているTODOは期日が現時点(<span th:text="${dayOfNow}"></span>)より7日以内のものです
+			※赤く表示されているTODOは期日が現時点(<span th:text="${today}"></span>)より7日以内のものです
 		</p>
 		<table class="table">
 			<thead>
@@ -55,11 +55,11 @@
 			</thead>
 			<tbody>
 				<tr th:each="item, status : ${data}">
-					<td th:text="${status.count}" th:class="${deadlineFlagLists[status.index]} ? 'nearbyDeadlines' : ''"></td>
-					<td th:text="${item.done} ? '完了' : '未完了'" th:class="${deadlineFlagLists[status.index]} ? 'nearbyDeadlines' : ''"></td>
-					<td th:text="${item.content}" th:class="${deadlineFlagLists[status.index]} ? 'nearbyDeadlines' : ''"></td>
-					<td th:text="${item.created}" th:class="${deadlineFlagLists[status.index]} ? 'nearbyDeadlines' : ''"></td>
-					<td th:text="${item.deadline}" th:class="${deadlineFlagLists[status.index]} ? 'nearbyDeadlines' : ''"></td>
+					<td th:text="${status.count}" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
+					<td th:text="${item.done} ? '完了' : '未完了'" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
+					<td th:text="${item.content}" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
+					<td th:text="${item.created}" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
+					<td th:text="${item.deadline}" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
 				</tr>
 			</tbody>
 		</table>


### PR DESCRIPTION
TODOアプリの作成にて以下の機能を追加しましたので、レビューをお願いいたします。

・作成したもの
→「TODO閲覧機能」
→参考）[仕様](https://sites.google.com/scalehack.co.jp/codestep-academy/welcome/c/exercise/springboot-todo)

・見てほしい点
→ログインすれば自分の作成したTODO一覧を閲覧できる
→管理者専用ページを作成し管理者ユーザはそこへアクセスできる。そのページでは全ユーザーのTODO一覧を閲覧できる
→管理者専用ページへのリンクは管理者でログインしないと表示されない
→期日が閲覧時点から７日以内のTODOを赤く表示する

こちらテスト仕様書兼実績書です。
[テスト仕様書](https://docs.google.com/spreadsheets/d/1ulrbTCkV0cRPNmII-AMBNdX5ST5sm_JR_7aAo3yk_nY/edit?usp=drive_link)

以上、よろしくお願いいたします。