### PR TITLE
TODO更新機能追加

### DIFF
--- a/src/main/java/com/example/todoapp/AuthenticatedUserController.java
+++ b/src/main/java/com/example/todoapp/AuthenticatedUserController.java
@@ -87,9 +87,19 @@ public class AuthenticatedUserController {
 	@GetMapping("/edit/{id}")
 	@PreAuthorize("isAuthenticated()")
 	public ModelAndView edit(ModelAndView mav, @PathVariable int id) {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		String loggedInUser = authentication.getName();		// ログイン中のユーザー名
+		
+		Optional<Todo> data = repository.findById((long)id);
+		String todoCreateUser = data.get().getUsername();	// TODO作成者のユーザー名
+		
+		// ログイン中のユーザー名と、TODO作成者の名前が一致しないとTOPページへリダイレクトする
+		if(!loggedInUser.equals(todoCreateUser)) {
+			return new ModelAndView("redirect:/");
+		}
+		
 		mav.setViewName("todo/edit");
 		mav.addObject("title", "TODO更新ページ");
-		Optional<Todo> data = repository.findById((long)id);
 		mav.addObject("formModel", data.get());
 		return mav;
 	}

--- a/src/main/java/com/example/todoapp/AuthenticatedUserController.java
+++ b/src/main/java/com/example/todoapp/AuthenticatedUserController.java
@@ -3,6 +3,7 @@ package com.example.todoapp;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -13,6 +14,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
@@ -78,6 +80,34 @@ public class AuthenticatedUserController {
 		}
 		
 		todoService.create(username, todoItem);
+		
+		return new ModelAndView("redirect:/todo/create");
+	}
+	
+	@GetMapping("/edit/{id}")
+	@PreAuthorize("isAuthenticated()")
+	public ModelAndView edit(ModelAndView mav, @PathVariable int id) {
+		mav.setViewName("todo/edit");
+		mav.addObject("title", "TODO更新ページ");
+		Optional<Todo> data = repository.findById((long)id);
+		mav.addObject("formModel", data.get());
+		return mav;
+	}
+	
+	@PostMapping("/edit")
+	@PreAuthorize("isAuthenticated()")
+	public ModelAndView update(ModelAndView mav, @ModelAttribute("formModel") @Validated Todo todoItem, BindingResult result) {
+		if(result.hasErrors()) {
+			mav.setViewName("todo/edit");
+			mav.addObject("title", "TODO更新ページ");
+			mav.addObject("formModel", todoItem);
+			return mav;
+		}
+		
+		Optional<Todo> data = repository.findById(todoItem.getId());
+		Todo originalData = data.get();
+		
+		todoService.update(originalData, todoItem);
 		
 		return new ModelAndView("redirect:/todo/create");
 	}

--- a/src/main/java/com/example/todoapp/Todo.java
+++ b/src/main/java/com/example/todoapp/Todo.java
@@ -99,5 +99,15 @@ public class Todo {
 	public void setDeadline(LocalDate deadline) {
 		this.deadline = deadline;
 	}
+	
+	@Override
+	public String toString() {
+		return  "ID： " + this.getId() + "\n" +
+				"名前： " + this.getUsername() + "\n" +
+				"TODO； " + this.getContent() + "\n" +
+				"完了状態： " + this.isDone() + "\n" +
+				"作成日： " + this.getCreated() + "\n" +
+				"期日： " + this.getDeadline();
+	}
 
 }

--- a/src/main/java/com/example/todoapp/TodoController.java
+++ b/src/main/java/com/example/todoapp/TodoController.java
@@ -55,16 +55,3 @@ public class TodoController {
 		return mav;
 	}
 }
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/main/java/com/example/todoapp/TodoService.java
+++ b/src/main/java/com/example/todoapp/TodoService.java
@@ -24,5 +24,12 @@ public class TodoService {
 		repository.saveAndFlush(item);
 		return item;
 	}
+	
+	// ToDo更新機能
+	public void update(Todo originalData, Todo newData) {
+		originalData.setContent(newData.getContent());
+		originalData.setDeadline(newData.getDeadline());
+		repository.saveAndFlush(originalData);
+	}
 
 }

--- a/src/main/resources/templates/todo/create.html
+++ b/src/main/resources/templates/todo/create.html
@@ -51,6 +51,7 @@
 					<th>TODO</th>
 					<th>作成日</th>
 					<th>期日</th>
+					<th>更新</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -60,6 +61,7 @@
 					<td th:text="${item.content}" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
 					<td th:text="${item.created}" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
 					<td th:text="${item.deadline}" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
+					<td><a th:href="@{/todo/edit/{id}(id = ${item.id})}">更新する</a></td>
 				</tr>
 			</tbody>
 		</table>

--- a/src/main/resources/templates/todo/edit.html
+++ b/src/main/resources/templates/todo/edit.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title th:text="${title}"></title>
+		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"
+			integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
+		<style>
+			.err { color: red; }
+		</style>
+	</head>
+	<body class="container">
+		<h1 class="display-4 mb-4" th:text="${title}"></h1>
+		<p class="fs-5">
+			<a class="fw-bold" th:href="@{/}">トップページへ</a>
+			<a class="fw-bold" th:href="@{/logout}">ログアウトする</a>
+		</p>
+		
+		<h2 class="fw-bold mt-5">TODO更新</h2>
+		<form method="post" th:action="@{/todo/edit}" th:object="${formModel}">
+			<input type="hidden" name="id" th:value="*{id}">
+			
+			<div class="mb-4">
+				<label class="form-label" for="content">TODO</label>
+				<input class="form-control" type="text" id="content" name="content" th:value="*{content}">
+				<p th:if="${#fields.hasErrors('content')}" th:errors="*{content}" th:errorclass="err"></p>
+			</div>
+			
+			<div class="mb-4">
+				<label class="form-label" for="deadline">期日</label>
+				<input class="form-control" type="date" id="deadline" name="deadline" th:value="*{deadline}">
+				<p th:if="${#fields.hasErrors('deadline')}" th:errors="*{deadline}" th:errorclass="err"></p>
+			</div>
+			
+			<input type="submit" class="btn btn-primary mx-4" value="更新する">
+			<span><a th:href="@{/todo/create}">戻る</a></span>
+		</form>
+		
+	</body>
+</html>


### PR DESCRIPTION
TODOアプリの作成にて以下の機能を追加しましたので、レビューをお願いいたします。

・作成したもの
→「TODO更新機能」
→参考）[仕様](https://sites.google.com/scalehack.co.jp/codestep-academy/welcome/c/exercise/springboot-todo)

・見てほしい点
→TODO一覧に「更新する」リンク追加し、押すと該当するTODOの更新ページに遷移する(edit.html)
→更新ページで更新できるのはTODOと期日の２つのみ、他のユーザー名、作成日、完了状態はそのまま保持
→サービスクラスに更新機能のメソッド追加
更新処理の内容は、元データに対してフォームより送信されてきた新しい内容を上書きし保存するようにしています。
→テスト内容がTODO登録機能の時のテスト内容とほぼ同じものになっています

こちらテスト仕様書兼実績書です。
[テスト仕様書](https://docs.google.com/spreadsheets/d/1ulrbTCkV0cRPNmII-AMBNdX5ST5sm_JR_7aAo3yk_nY/edit?usp=drive_link)

以上、よろしくお願いいたします。