### PR TITLE
TODO削除機能追加

### DIFF
--- a/src/main/java/com/example/todoapp/AuthenticatedUserController.java
+++ b/src/main/java/com/example/todoapp/AuthenticatedUserController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
 import com.example.todoapp.repositories.TodoRepository;
@@ -120,6 +121,26 @@ public class AuthenticatedUserController {
 		todoService.update(originalData, todoItem);
 		
 		return new ModelAndView("redirect:/todo/create");
+	}
+	
+	@GetMapping("/delete/{id}")
+	@PreAuthorize("hasRole('ADMIN')")
+	public ModelAndView delete(ModelAndView mav, @PathVariable int id) {
+		mav.setViewName("todo/delete");
+		mav.addObject("title", "TODO削除ページ");
+		mav.addObject("msg", "こちらのTODOを削除してもよろしいでしょうか？");
+		
+		Optional<Todo> data = repository.findById((long)id);
+		mav.addObject("formModel", data.get());
+		
+		return mav;
+	}
+	
+	@PostMapping("/delete")
+	@PreAuthorize("hasRole('ADMIN')")
+	public ModelAndView remove(ModelAndView mav, @RequestParam long id) {
+		todoService.delete(id);
+		return new ModelAndView("redirect:/todo/admin");
 	}
 	
 	@GetMapping("/admin")

--- a/src/main/java/com/example/todoapp/TodoService.java
+++ b/src/main/java/com/example/todoapp/TodoService.java
@@ -31,5 +31,10 @@ public class TodoService {
 		originalData.setDeadline(newData.getDeadline());
 		repository.saveAndFlush(originalData);
 	}
+	
+	// ToDo削除機能
+	public void delete(long id) {
+		repository.deleteById(id);
+	}
 
 }

--- a/src/main/resources/templates/todo/admin.html
+++ b/src/main/resources/templates/todo/admin.html
@@ -34,6 +34,7 @@
 					<th>TODO</th>
 					<th>作成日</th>
 					<th>期日</th>
+					<th>削除</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -44,6 +45,7 @@
 					<td th:text="${item.content}" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
 					<td th:text="${item.created}" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
 					<td th:text="${item.deadline}" th:class="${deadlineFlagList[status.index]} ? 'nearbyDeadlines' : ''"></td>
+					<td><a th:href="@{/todo/delete/{id}(id = ${item.id})}">削除する</a></td>
 				</tr>
 			</tbody>
 		</table>

--- a/src/main/resources/templates/todo/delete.html
+++ b/src/main/resources/templates/todo/delete.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title th:text="${title}"></title>
+		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"
+			integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
+	</head>
+	<body class="container">
+		<h1 class="display-4 mb-4" th:text="${title}"></h1>
+		<p class="fs-5">
+			<a class="fw-bold" th:href="@{/}">トップページへ</a>
+			<a class="fw-bold" th:href="@{/logout}">ログアウトする</a>
+		</p>
+		
+		<h2 class="fw-bold mt-5" th:text="${msg}"></h2>
+		<form method="post" th:action="@{/todo/delete}" th:object="${formModel}">
+			<input type="hidden" name="id" th:value="*{id}">
+			
+			<ul>
+				<li>作成者: <span th:text="*{username}"></span></li>
+				<li>完了状態: <span th:text="*{done} ? '完了' : '未完了'"></span></li>
+				<li>TODO: <span th:text="*{content}"></span>
+				<li>作成日: <span th:text="*{created}"></span></li>
+				<li>期日: <span th:text="*{deadline}"></span></li>
+			</ul>
+			
+			
+			<input type="submit" class="btn btn-primary mx-4" value="削除する">
+			<span><a th:href="@{/todo/admin}">キャンセル</a></span>
+		</form>
+		
+	</body>
+</html>


### PR DESCRIPTION
TODOアプリの作成にて以下の機能を追加しましたので、レビューをお願いいたします。

・作成したもの
→「TODO削除機能」
→参考）[仕様](https://sites.google.com/scalehack.co.jp/codestep-academy/welcome/c/exercise/springboot-todo)

・見てほしい点
→管理者専用ページに表示される全ユーザーのTODO一覧それぞれに「削除する」リンクを追加。このリンクを押下後、その対象TODOの削除ページへ画面遷移する(delete.html)
→管理者専用ページは管理者ユーザーしかアクセスできないため、一般ユーザーでは削除機能は使えない。また、削除ページ自体にも管理者権限でのアクセス制限を付与している
→削除ページでは対象TODOの情報を表示させ、削除確認メッセージを表示する
→「削除する」ボタンを押下すると、対象TODOが削除される

こちらテスト仕様書兼実績書です。
[テスト仕様書](https://docs.google.com/spreadsheets/d/1ulrbTCkV0cRPNmII-AMBNdX5ST5sm_JR_7aAo3yk_nY/edit?usp=drive_link)

以上、よろしくお願いいたします。